### PR TITLE
Auto qr type when typeNumber is null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,3 +23,5 @@
 ## [2.0.0] - Null safety
 
 ## [2.0.1] - Rework imports
+
+## [2.0.2] - Auto typeNumber when null

--- a/README.md
+++ b/README.md
@@ -31,18 +31,22 @@ class MyApp extends StatelessWidget {
     return MaterialApp(
       home: Scaffold(
         body: Center(
-            child: PrettyQr(
-                image: AssetImage('images/twitter.png'),
-                typeNumber: 3,
-                size: 200,
-                data: 'https://www.google.ru',
-                errorCorrectLevel: QrErrorCorrectLevel.M,
-                roundEdges: true)),
+          child: PrettyQr(
+            image: AssetImage('images/twitter.png'),
+            typeNumber: 3,
+            size: 200,
+            data: 'https://www.google.ru',
+            errorCorrectLevel: QrErrorCorrectLevel.M,
+            roundEdges: true,
+          ),
+        ),
       ),
     );
   }
 }
 ```
+
+`typeNumber` is null by default. It means that it will be automatically chosen based on `data` length
 
 ## Getting Started
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:pretty_qr_code/pretty_qr_code.dart';
 
-
 void main() => runApp(MyApp());
 
 class MyApp extends StatelessWidget {
@@ -22,13 +21,16 @@ class _MyHomePageState extends State<MyHomePage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-        body: Center(
-            child: PrettyQr(
-                image: AssetImage('images/twitter.png'),
-                typeNumber: 3,
-                size: 300,
-                data: 'https://www.google.ru',
-                errorCorrectLevel: QrErrorCorrectLevel.M,
-                roundEdges: true)));
+      body: Center(
+        child: PrettyQr(
+          image: AssetImage('images/twitter.png'),
+          size: 300,
+          data: 'https://www.google.ru',
+          errorCorrectLevel: QrErrorCorrectLevel.M,
+          typeNumber: null,
+          roundEdges: true,
+        ),
+      ),
+    );
   }
 }

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -94,7 +94,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.0.1"
+    version: "2.0.2"
   qr:
     dependency: "direct main"
     description:

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0"
+    version: "2.6.1"
   boolean_selector:
     dependency: transitive
     description:
@@ -49,7 +49,7 @@ packages:
       name: cupertino_icons
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.2"
+    version: "0.1.3"
   fake_async:
     dependency: transitive
     description:
@@ -91,12 +91,12 @@ packages:
   pretty_qr_code:
     dependency: "direct main"
     description:
-      name: pretty_qr_code
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.0.0"
+      path: ".."
+      relative: true
+    source: path
+    version: "2.0.1"
   qr:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: qr
       url: "https://pub.dartlang.org"
@@ -113,7 +113,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
@@ -148,7 +148,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19"
+    version: "0.3.0"
   typed_data:
     dependency: transitive
     description:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -23,8 +23,12 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^0.1.2
-  pretty_qr_code: ^2.0.0
+  pretty_qr_code:
+  qr: ^2.0.0
 
+dependency_overrides:
+  pretty_qr_code:
+    path: ../
 
 dev_dependencies:
   flutter_test:

--- a/lib/src/pretty_qr.dart
+++ b/lib/src/pretty_qr.dart
@@ -23,8 +23,8 @@ class PrettyQr extends StatefulWidget {
   ///Round the corners
   final bool roundEdges;
 
-  ///Number of type generation (1 to 40)
-  final int typeNumber;
+  ///Number of type generation (1 to 40 or null for auto)
+  final int? typeNumber;
 
   final ImageProvider? image;
 
@@ -35,7 +35,7 @@ class PrettyQr extends StatefulWidget {
       this.elementColor = Colors.black,
       this.errorCorrectLevel = QrErrorCorrectLevel.M,
       this.roundEdges = false,
-      this.typeNumber = 1,
+      this.typeNumber,
       this.image})
       : super(key: key);
 

--- a/lib/src/pretty_qr_painter.dart
+++ b/lib/src/pretty_qr_painter.dart
@@ -4,36 +4,44 @@ import 'package:flutter/material.dart';
 import 'package:qr/qr.dart';
 
 class PrettyQrCodePainter extends CustomPainter {
-  final String? data;
+  final String data;
   final Color elementColor;
   final int errorCorrectLevel;
-  final int typeNumber;
   final bool roundEdges;
   ui.Image? image;
   late QrCode _qrCode;
   int deletePixelCount = 0;
 
   PrettyQrCodePainter(
-      {this.data,
+      {required this.data,
       this.elementColor = Colors.black,
       this.errorCorrectLevel = QrErrorCorrectLevel.M,
       this.roundEdges = false,
-      this.typeNumber = 1,
-      this.image}) {
-    _qrCode = QrCode(typeNumber, errorCorrectLevel);
-    _qrCode.addData(data!);
+      this.image,
+      int? typeNumber,
+  }) {
+    if (typeNumber == null) {
+      _qrCode = QrCode.fromData(
+        data: data, 
+        errorCorrectLevel: errorCorrectLevel,
+      );
+    } else {
+      _qrCode = QrCode(typeNumber, errorCorrectLevel);
+      _qrCode.addData(data);
+    }
+
     _qrCode.make();
   }
 
   @override
   paint(Canvas canvas, Size size) {
     if (image != null) {
-      if (this.typeNumber <= 2) {
-        deletePixelCount = this.typeNumber + 7;
-      } else if (this.typeNumber <= 4) {
-        deletePixelCount = this.typeNumber + 8;
+      if (this._qrCode.typeNumber <= 2) {
+        deletePixelCount = this._qrCode.typeNumber + 7;
+      } else if (this._qrCode.typeNumber <= 4) {
+        deletePixelCount = this._qrCode.typeNumber + 8;
       } else {
-        deletePixelCount = this.typeNumber + 9;
+        deletePixelCount = this._qrCode.typeNumber + 9;
       }
 
       var imageSize = Size(image!.width.toDouble(), image!.height.toDouble());

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0"
+    version: "2.6.1"
   boolean_selector:
     dependency: transitive
     description:
@@ -99,7 +99,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
@@ -134,7 +134,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19"
+    version: "0.3.0"
   typed_data:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pretty_qr_code
 description: Pretty QR code for Flutter. You can round the edges with parameter or use the standard view.
-version: 2.0.1
+version: 2.0.2
 homepage: https://github.com/promops/flutter_pretty_qr
 
 environment:


### PR DESCRIPTION
`qr` dependency exposes a factory which determine by itself the lowest type that can be used.
This PR uses this factory in case `typeNumber` is null