### PR TITLE
Add border radius support for embedded image

### DIFF
--- a/lib/src/painting/decoration/pretty_qr_decoration_image.dart
+++ b/lib/src/painting/decoration/pretty_qr_decoration_image.dart
@@ -27,10 +27,7 @@ class PrettyQrDecorationImage extends DecorationImage {
   /// {@macro pretty_qr_code.painting.PrettyQrDecorationImagePosition}
   final PrettyQrDecorationImagePosition position;
 
-  /// The border radius of the embedded image.
-  ///
-  /// When the position is [PrettyQrDecorationImagePosition.embedded],
-  /// this value will be used to round the corners of the image.
+  /// The border radius of the image.
   final BorderRadius? borderRadius;
 
   /// Creates an image to show into QR code.

--- a/lib/src/painting/decoration/pretty_qr_decoration_image.dart
+++ b/lib/src/painting/decoration/pretty_qr_decoration_image.dart
@@ -27,6 +27,12 @@ class PrettyQrDecorationImage extends DecorationImage {
   /// {@macro pretty_qr_code.painting.PrettyQrDecorationImagePosition}
   final PrettyQrDecorationImagePosition position;
 
+  /// The border radius of the embedded image.
+  ///
+  /// When the position is [PrettyQrDecorationImagePosition.embedded],
+  /// this value will be used to round the corners of the image.
+  final BorderRadius? borderRadius;
+
   /// Creates an image to show into QR code.
   ///
   /// Not recommended to use scale over `0.2`, see the QR code
@@ -46,6 +52,7 @@ class PrettyQrDecorationImage extends DecorationImage {
     super.isAntiAlias = false,
     this.padding = EdgeInsets.zero,
     this.position = PrettyQrDecorationImagePosition.embedded,
+    this.borderRadius,
   }) : assert(scale >= 0 && scale <= 1);
 
   /// Creates a copy of this [PrettyQrDecorationImage] but with the given fields
@@ -66,6 +73,7 @@ class PrettyQrDecorationImage extends DecorationImage {
     final bool? isAntiAlias,
     final EdgeInsetsGeometry? padding,
     final PrettyQrDecorationImagePosition? position,
+    final BorderRadius? borderRadius,
   }) {
     return PrettyQrDecorationImage(
       image: image ?? this.image,
@@ -81,6 +89,7 @@ class PrettyQrDecorationImage extends DecorationImage {
       isAntiAlias: isAntiAlias ?? this.isAntiAlias,
       padding: padding ?? this.padding,
       position: position ?? this.position,
+      borderRadius: borderRadius ?? this.borderRadius,
     );
   }
 
@@ -106,6 +115,7 @@ class PrettyQrDecorationImage extends DecorationImage {
         scale: b.scale * t,
         opacity: b.opacity * t,
         padding: EdgeInsetsGeometry.lerp(null, b.padding, t)!,
+        borderRadius: BorderRadius.lerp(null, b.borderRadius, t),
       );
     }
 
@@ -114,6 +124,7 @@ class PrettyQrDecorationImage extends DecorationImage {
         scale: a.scale * (1.0 - t),
         opacity: a.opacity * (1.0 - t),
         padding: EdgeInsetsGeometry.lerp(a.padding, null, t)!,
+        borderRadius: BorderRadius.lerp(a.borderRadius, null, t),
       );
     }
 
@@ -121,12 +132,13 @@ class PrettyQrDecorationImage extends DecorationImage {
       scale: lerpDouble(a.scale, b.scale, t)!,
       opacity: lerpDouble(a.opacity, b.opacity, t)!,
       padding: EdgeInsetsGeometry.lerp(a.padding, b.padding, t)!,
+      borderRadius: BorderRadius.lerp(a.borderRadius, b.borderRadius, t),
     );
   }
 
   @override
   int get hashCode {
-    return super.hashCode ^ Object.hash(runtimeType, padding);
+    return super.hashCode ^ Object.hash(runtimeType, padding, borderRadius);
   }
 
   @override
@@ -137,6 +149,7 @@ class PrettyQrDecorationImage extends DecorationImage {
     return other is PrettyQrDecorationImage &&
         super == other &&
         other.padding == padding &&
-        other.position == position;
+        other.position == position &&
+        other.borderRadius == borderRadius;
   }
 }

--- a/lib/src/painting/pretty_qr_painter.dart
+++ b/lib/src/painting/pretty_qr_painter.dart
@@ -103,10 +103,13 @@ class PrettyQrPainter {
       final imageCroppedRect = imagePadding.deflateRect(imageScaledRect);
 
       _decorationImagePainter ??= image.createPainter(onChanged);
+      final clipPath = image.borderRadius == null ? null : Path()
+        ?..addRRect(imageRRect)
+        ..close();
       _decorationImagePainter?.paint(
         context.canvas,
         imageCroppedRect,
-        null,
+        clipPath,
         configuration.copyWith(size: imageCroppedRect.size),
       );
     }

--- a/lib/src/painting/pretty_qr_painter.dart
+++ b/lib/src/painting/pretty_qr_painter.dart
@@ -69,12 +69,25 @@ class PrettyQrPainter {
         width: size.width * imageScale,
         height: size.height * imageScale,
       );
+      final imageRRect = image.borderRadius == null
+          ? RRect.fromRectXY(imageScaledRect, 0, 0)
+          : RRect.fromRectAndCorners(
+              imageScaledRect,
+              topLeft: image.borderRadius!.topLeft,
+              topRight: image.borderRadius!.topRight,
+              bottomLeft: image.borderRadius!.bottomLeft,
+              bottomRight: image.borderRadius!.bottomRight,
+            );
 
       // clear space for the embedded image
       if (image.position == PrettyQrDecorationImagePosition.embedded) {
         for (final module in context.matrix) {
           final moduleRect = module.resolveRect(context);
-          if (imageScaledRect.overlaps(moduleRect)) {
+          if (imageRRect.contains(Offset(moduleRect.left, moduleRect.top)) ||
+              imageRRect.contains(Offset(moduleRect.right, moduleRect.top)) ||
+              imageRRect.contains(Offset(moduleRect.left, moduleRect.bottom)) ||
+              imageRRect
+                  .contains(Offset(moduleRect.right, moduleRect.bottom))) {
             context.matrix.removeDarkAt(module.x, module.y);
           }
         }


### PR DESCRIPTION
PrettyQrDecorationImage add borderRadius parameter. When the position is [PrettyQrDecorationImagePosition.embedded], this value will be used to round the corners of the image.